### PR TITLE
Changing the type of attribute UniqueId to string

### DIFF
--- a/PavlovVR-Rcon/Models/Pavlov/Player.cs
+++ b/PavlovVR-Rcon/Models/Pavlov/Player.cs
@@ -2,7 +2,7 @@
 
 public class Player
 {
-    public ulong? UniqueId { get; init; } = null;
+    public string UniqueId { get; init; } = string.Empty;
 
     public string Username { get; init; } = string.Empty;
 }

--- a/PavlovVR-Rcon/Models/Pavlov/PlayerDetail.cs
+++ b/PavlovVR-Rcon/Models/Pavlov/PlayerDetail.cs
@@ -2,7 +2,7 @@
 
 public class PlayerDetail
 {
-    public ulong UniqueId { get; init; }
+    public string UniqueId { get; init; } = string.Empty;
     public string PlayerName { get; init; } = string.Empty;
     public string KDA { get; init; } = string.Empty;
     public int Cash { get; init; }


### PR DESCRIPTION
I`m making this change because in the game **Pavlov Shack** the UniqueId attribute is identical to the Username. 
When receiving a reply from RCON the JsonConverter raised an exception for trying to convert a string to ulong.