### PR TITLE
Adding new members to ServerInfo class.

### DIFF
--- a/PavlovVR-Rcon/Models/Pavlov/ServerInfo.cs
+++ b/PavlovVR-Rcon/Models/Pavlov/ServerInfo.cs
@@ -3,7 +3,10 @@
 public class ServerInfo
 {
     public string MapLabel { get; init; } = string.Empty;
+    public string MapName { get; init; } = string.Empty;
     public string GameMode { get; init; } = string.Empty;
+    public string GameModeName { get; init; } = string.Empty;
+    public string[] Mods { get; init; } = Array.Empty<string>();
     public string ServerName { get; init; } = string.Empty;
     public bool Teams { get; init; }
     public int? Team0Score { get; init; }


### PR DESCRIPTION
In the last update, new information was added to the `ServerInfo` command.

One example of the current return of the `ServerInfo` is:
```
{
        "Command": "ServerInfo",
        "ServerInfo":
        {
                "MapLabel": "UGC3061028",
                "MapName": "Vice",
                "GameMode": "SND",
                "GameModeName": "SND",
                "Mods": [
                        "UGC1234567",
                        "UGC7654321"
                ],
                "ServerName": "Server name",
                "Teams": true,
                "Team0Score": "0",
                "Team1Score": "8",
                "Round": "8",
                "RoundState": "StandBy",
                "PlayerCount": "0/18"
        },
        "Successful": true
}
```